### PR TITLE
feat: add audit trail model and interceptor tests

### DIFF
--- a/apps/api/src/common/interceptors/audit-trail.interceptor.ts
+++ b/apps/api/src/common/interceptors/audit-trail.interceptor.ts
@@ -25,7 +25,12 @@ export class AuditTrailInterceptor implements NestInterceptor {
           return;
         }
 
-        const scope = request.headers['x-audit-scope']?.toString() ?? AuditTrailScope.ENGAGEMENT;
+        const scopeHeader = request.headers['x-audit-scope']?.toString();
+        const normalizedScope = scopeHeader?.replace(/[-\s]/g, '_').toUpperCase();
+        const scope =
+          normalizedScope && (Object.values(AuditTrailScope) as string[]).includes(normalizedScope)
+            ? (normalizedScope as AuditTrailScope)
+            : AuditTrailScope.ENGAGEMENT;
         const entityId = request.headers['x-entity-id']?.toString() ?? 'unknown';
         const entityType = request.headers['x-entity-type']?.toString() ?? request.route?.path ?? 'unknown';
 
@@ -33,7 +38,7 @@ export class AuditTrailInterceptor implements NestInterceptor {
           data: {
             tenantId: user.tenantId,
             actorId: user.sub,
-            scope: scope as AuditTrailScope,
+            scope,
             entityId,
             entityType,
             action: `${request.method} ${request.originalUrl}`,

--- a/apps/api/test/audit-trail.interceptor.spec.ts
+++ b/apps/api/test/audit-trail.interceptor.spec.ts
@@ -1,0 +1,91 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { describe, expect, it, jest } from '@jest/globals';
+import { AuditTrailScope } from '@prisma/client';
+import { of, lastValueFrom } from 'rxjs';
+import { AuditTrailInterceptor } from '../src/common/interceptors/audit-trail.interceptor';
+import { PrismaService } from '../src/common/prisma/prisma.service';
+
+describe('AuditTrailInterceptor', () => {
+  const createExecutionContext = (request: unknown, response: unknown): ExecutionContext => {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response
+      })
+    } as unknown as ExecutionContext;
+  };
+
+  it('records an audit trail entry with normalized scope metadata', async () => {
+    const create = jest.fn();
+    const prisma = { auditTrailEvent: { create } } as unknown as PrismaService;
+    const interceptor = new AuditTrailInterceptor(prisma);
+
+    const request = {
+      headers: {
+        'x-audit-scope': 'risk',
+        'x-entity-id': 'risk-123',
+        'x-entity-type': 'risk'
+      },
+      user: {
+        tenantId: 'tenant-1',
+        sub: 'user-1'
+      },
+      method: 'POST',
+      originalUrl: '/risks',
+      route: { path: '/risks' }
+    };
+
+    const response = { statusCode: 201 };
+
+    const next: CallHandler = {
+      handle: () => of({ ok: true })
+    };
+
+    const result$ = interceptor.intercept(createExecutionContext(request, response), next);
+
+    await lastValueFrom(result$);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tenantId: 'tenant-1',
+        actorId: 'user-1',
+        scope: AuditTrailScope.RISK,
+        entityId: 'risk-123',
+        entityType: 'risk',
+        action: 'POST /risks',
+        metadata: expect.objectContaining({
+          statusCode: 201,
+          response: { ok: true }
+        })
+      })
+    });
+  });
+
+  it('skips persistence when no tenant scope is available', async () => {
+    const create = jest.fn();
+    const prisma = { auditTrailEvent: { create } } as unknown as PrismaService;
+    const interceptor = new AuditTrailInterceptor(prisma);
+
+    const request = {
+      headers: {},
+      user: {},
+      method: 'GET',
+      originalUrl: '/healthz'
+    };
+
+    const response = { statusCode: 200 };
+
+    const next: CallHandler = {
+      handle: () => of({ healthy: true })
+    };
+
+    const result$ = interceptor.intercept(createExecutionContext(request, response), next);
+
+    await lastValueFrom(result$);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/prisma/prisma/migrations/20250921125504_add_audit_trail/migration.sql
+++ b/packages/prisma/prisma/migrations/20250921125504_add_audit_trail/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "AuditTrailScope" AS ENUM ('TENANT', 'RISK', 'CONTROL', 'ASSESSMENT', 'ENGAGEMENT', 'FINDING', 'REPORT', 'SYSTEM');
+
+-- CreateTable
+CREATE TABLE "AuditTrailEvent" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "actorId" TEXT,
+    "scope" "AuditTrailScope" NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditTrailEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AuditTrailEvent_tenantId_scope_idx" ON "AuditTrailEvent"("tenantId", "scope");
+CREATE INDEX "AuditTrailEvent_tenantId_entityType_entityId_idx" ON "AuditTrailEvent"("tenantId", "entityType", "entityId");
+
+-- AddForeignKey
+ALTER TABLE "AuditTrailEvent" ADD CONSTRAINT "AuditTrailEvent_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AuditTrailEvent" ADD CONSTRAINT "AuditTrailEvent_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/prisma/migrations/migration_lock.toml
+++ b/packages/prisma/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile, do not edit manually.
+provider = "postgresql"

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -15,6 +15,17 @@ enum Role {
   Viewer
 }
 
+enum AuditTrailScope {
+  TENANT
+  RISK
+  CONTROL
+  ASSESSMENT
+  ENGAGEMENT
+  FINDING
+  REPORT
+  SYSTEM
+}
+
 model Tenant {
   id         String          @id @default(cuid())
   name       String
@@ -33,6 +44,7 @@ model Tenant {
   reports    Report[]
   events     Event[]
   refreshTokens RefreshToken[]
+  auditTrailEvents AuditTrailEvent[]
 }
 
 model User {
@@ -50,6 +62,7 @@ model User {
   followUps FollowUp[] @relation("FollowUpVerifier")
   ownedRisks Risk[]   @relation("RiskOwner")
   refreshTokens RefreshToken[]
+  auditTrailEvents AuditTrailEvent[] @relation("AuditTrailActor")
 }
 
 model Risk {
@@ -339,6 +352,25 @@ model Event {
   diff     Json
   timestamp DateTime @default(now())
   tenant   Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+}
+
+model AuditTrailEvent {
+  id         String          @id @default(cuid())
+  tenantId   String
+  actorId    String?
+  scope      AuditTrailScope
+  entityId   String
+  entityType String
+  action     String
+  metadata   Json?
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  actor  User?  @relation("AuditTrailActor", fields: [actorId], references: [id], onDelete: SetNull)
+
+  @@index([tenantId, scope])
+  @@index([tenantId, entityType, entityId])
 }
 
 model RefreshToken {

--- a/packages/prisma/src/seed.ts
+++ b/packages/prisma/src/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Role } from '@prisma/client';
+import { AuditTrailScope, PrismaClient, Role } from '@prisma/client';
 
 
 const prisma = new PrismaClient();
@@ -272,6 +272,21 @@ async function main() {
       type: 'risk.seeded',
       diff: { status: 'Monitoring' }
 
+    }
+  });
+
+  await prisma.auditTrailEvent.create({
+    data: {
+      tenantId: tenant.id,
+      actorId: auditManager.id,
+      scope: AuditTrailScope.ENGAGEMENT,
+      entityId: engagement.id,
+      entityType: 'engagement',
+      action: 'seed.initialized',
+      metadata: {
+        source: 'seed-script',
+        description: 'Seed data created for demo tenant'
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- add a Prisma AuditTrailScope enum and AuditTrailEvent model with a corresponding migration and seed data
- normalise audit scope headers in the audit trail interceptor and persist events via the Prisma client
- add unit coverage that asserts an audit trail entry is written for tenant requests

## Testing
- pnpm --filter @open-erm/prisma exec prisma generate *(fails: Command "prisma" not found in the environment)*
- pnpm --filter @open-erm/api build *(fails: nest not found because dependencies are unavailable in the sandbox)*
- pnpm --filter @open-erm/api test *(fails: jest not found because dependencies are unavailable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cff473dbd483288b67692179d266e3