### PR TITLE
feat: expand audit planning, library, and timesheet capabilities

### DIFF
--- a/apps/api/src/audit/audit.controller.ts
+++ b/apps/api/src/audit/audit.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Headers, Param, Post, Get } from '@nestjs/common';
+import { Body, Controller, Headers, Param, Post, Get, Query } from '@nestjs/common';
 import { AuditService } from './audit.service';
 import { upsertAuditUniverseSchema } from './dto/upsert-audit-universe.dto';
 import { createAuditPlanSchema } from './dto/create-audit-plan.dto';
@@ -8,6 +8,16 @@ import { createWorkpaperSchema } from './dto/create-workpaper.dto';
 import { createFindingSchema } from './dto/create-finding.dto';
 import { createFollowUpSchema } from './dto/create-follow-up.dto';
 import { generateReportSchema } from './dto/generate-report.dto';
+import {
+  listLibraryItemsSchema,
+  upsertLibraryItemSchema
+} from './dto/upsert-library-item.dto';
+import { generateDraftScopeSchema } from './dto/generate-draft-scope.dto';
+import { createTimesheetEntrySchema, listTimesheetsSchema } from './dto/create-timesheet-entry.dto';
+import { approveTimesheetSchema } from './dto/approve-timesheet.dto';
+import { upsertAuditProgramSchema } from './dto/upsert-audit-program.dto';
+import { signWorkpaperSchema } from './dto/sign-workpaper.dto';
+import { upsertReportTemplateSchema } from './dto/upsert-report-template.dto';
 
 @Controller()
 export class AuditController {
@@ -21,6 +31,22 @@ export class AuditController {
   @Get('tenants/:tenantId/audit-dashboard')
   dashboard(@Param('tenantId') tenantId: string) {
     return this.auditService.dashboard(tenantId);
+  }
+
+  @Get('tenants/:tenantId/library-items')
+  listLibraryItems(@Param('tenantId') tenantId: string, @Query() query: Record<string, unknown>) {
+    const dto = listLibraryItemsSchema.parse(query);
+    return this.auditService.listLibraryItems(tenantId, dto);
+  }
+
+  @Post('tenants/:tenantId/library-items')
+  upsertLibraryItem(
+    @Param('tenantId') tenantId: string,
+    @Body() body: unknown,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = upsertLibraryItemSchema.parse(body);
+    return this.auditService.upsertLibraryItem(tenantId, dto, actorId ?? null);
   }
 
   @Post('tenants/:tenantId/audit-universe')
@@ -53,6 +79,17 @@ export class AuditController {
     return this.auditService.createEngagement(tenantId, dto, actorId ?? null);
   }
 
+  @Post('engagements/:engagementId/draft-scope')
+  generateDraftScope(
+    @Param('engagementId') engagementId: string,
+    @Body() body: unknown,
+    @Headers('x-tenant-id') tenantId: string,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = generateDraftScopeSchema.parse(body ?? {});
+    return this.auditService.generateDraftScope(tenantId, engagementId, dto, actorId ?? null);
+  }
+
   @Post('engagements/:engagementId/racm')
   upsertRacm(
     @Param('engagementId') engagementId: string,
@@ -75,6 +112,17 @@ export class AuditController {
     return this.auditService.addWorkpaper(tenantId, engagementId, dto, actorId ?? null);
   }
 
+  @Post('working-papers/:workpaperId/sign')
+  signWorkpaper(
+    @Param('workpaperId') workpaperId: string,
+    @Body() body: unknown,
+    @Headers('x-tenant-id') tenantId: string,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = signWorkpaperSchema.parse(body ?? {});
+    return this.auditService.signWorkpaper(tenantId, workpaperId, dto, actorId ?? null);
+  }
+
   @Post('engagements/:engagementId/findings')
   createFinding(
     @Param('engagementId') engagementId: string,
@@ -95,6 +143,69 @@ export class AuditController {
   ) {
     const dto = createFollowUpSchema.parse(body);
     return this.auditService.recordFollowUp(tenantId, findingId, dto, actorId ?? null);
+  }
+
+  @Post('tenants/:tenantId/timesheets')
+  createTimesheetEntry(
+    @Param('tenantId') tenantId: string,
+    @Body() body: unknown,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = createTimesheetEntrySchema.parse(body);
+    return this.auditService.createTimesheetEntry(tenantId, dto, actorId ?? null);
+  }
+
+  @Get('tenants/:tenantId/timesheets')
+  listTimesheets(@Param('tenantId') tenantId: string, @Query() query: Record<string, unknown>) {
+    const dto = listTimesheetsSchema.parse(query ?? {});
+    return this.auditService.listTimesheets(tenantId, dto);
+  }
+
+  @Post('tenants/:tenantId/timesheets/:timesheetId/approve')
+  approveTimesheet(
+    @Param('tenantId') tenantId: string,
+    @Param('timesheetId') timesheetId: string,
+    @Body() body: unknown,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = approveTimesheetSchema.parse(body ?? {});
+    return this.auditService.approveTimesheet(tenantId, timesheetId, dto, actorId ?? null);
+  }
+
+  @Get('tenants/:tenantId/audit-plans/:planId/utilization')
+  planUtilization(@Param('tenantId') tenantId: string, @Param('planId') planId: string) {
+    return this.auditService.planUtilization(tenantId, planId);
+  }
+
+  @Post('engagements/:engagementId/programs')
+  upsertProgram(
+    @Param('engagementId') engagementId: string,
+    @Body() body: unknown,
+    @Headers('x-tenant-id') tenantId: string,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = upsertAuditProgramSchema.parse(body);
+    return this.auditService.upsertAuditProgram(tenantId, engagementId, dto, actorId ?? null);
+  }
+
+  @Get('engagements/:engagementId/programs/latest')
+  latestProgram(@Param('engagementId') engagementId: string, @Headers('x-tenant-id') tenantId: string) {
+    return this.auditService.getLatestProgram(tenantId, engagementId);
+  }
+
+  @Post('tenants/:tenantId/report-templates')
+  upsertReportTemplate(
+    @Param('tenantId') tenantId: string,
+    @Body() body: unknown,
+    @Headers('x-user-id') actorId?: string
+  ) {
+    const dto = upsertReportTemplateSchema.parse(body);
+    return this.auditService.upsertReportTemplate(tenantId, dto, actorId ?? null);
+  }
+
+  @Get('tenants/:tenantId/report-templates')
+  listReportTemplates(@Param('tenantId') tenantId: string) {
+    return this.auditService.listReportTemplates(tenantId);
   }
 
   @Post('reports/generate')

--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -3,10 +3,11 @@ import { PrismaModule } from '../common/prisma/prisma.module';
 import { EventsModule } from '../events/events.module';
 import { AuditService } from './audit.service';
 import { AuditController } from './audit.controller';
+import { DeterministicPlanningProvider } from './planning/planning.provider';
 
 @Module({
   imports: [PrismaModule, EventsModule],
-  providers: [AuditService],
+  providers: [AuditService, DeterministicPlanningProvider],
   controllers: [AuditController]
 })
 export class AuditModule {}

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,5 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { differenceInDays } from 'date-fns';
+import { createHash, randomUUID } from 'crypto';
+import PDFDocument from 'pdfkit';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { EventsService } from '../events/events.service';
@@ -11,13 +13,40 @@ import { CreateWorkpaperDto } from './dto/create-workpaper.dto';
 import { CreateFindingDto } from './dto/create-finding.dto';
 import { CreateFollowUpDto } from './dto/create-follow-up.dto';
 import { GenerateReportDto } from './dto/generate-report.dto';
+import { ListLibraryItemsDto, UpsertLibraryItemDto } from './dto/upsert-library-item.dto';
+import { GenerateDraftScopeDto } from './dto/generate-draft-scope.dto';
+import { ApproveTimesheetDto } from './dto/approve-timesheet.dto';
+import { CreateTimesheetEntryDto, ListTimesheetsDto } from './dto/create-timesheet-entry.dto';
+import { UpsertAuditProgramDto } from './dto/upsert-audit-program.dto';
+import { SignWorkpaperDto } from './dto/sign-workpaper.dto';
+import { UpsertReportTemplateDto } from './dto/upsert-report-template.dto';
+import { DeterministicPlanningProvider } from './planning/planning.provider';
+
+type ResourceModel = {
+  capacity?: Record<string, number>;
+  allocations?: Array<{ engagementId: string; role?: string | null; hours: number }>;
+};
+
+type ReportSection = { title: string; body: string };
+
+type EngagementPlanInput = {
+  title: string;
+  entityRef?: string | null;
+  criticality?: number | null;
+  priority?: number | null;
+  riskScore?: number | null;
+};
 
 @Injectable()
 export class AuditService {
-  constructor(private readonly prisma: PrismaService, private readonly events: EventsService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly events: EventsService,
+    private readonly planningProvider: DeterministicPlanningProvider
+  ) {}
 
   async upsertAuditUniverse(tenantId: string, dto: UpsertAuditUniverseDto, actorId?: string | null) {
-    const results = [];
+    const results: Prisma.AuditUniverse[] = [];
 
     for (const entity of dto.entities) {
       if (entity.id) {
@@ -66,7 +95,78 @@ export class AuditService {
     return results;
   }
 
+  async listLibraryItems(tenantId: string, dto: ListLibraryItemsDto) {
+    const where: Prisma.LibraryItemWhereInput = {
+      tenantId,
+      ...(dto.type ? { type: dto.type } : {})
+    };
+
+    if (dto.search) {
+      where.OR = [
+        { title: { contains: dto.search, mode: 'insensitive' } },
+        { description: { contains: dto.search, mode: 'insensitive' } },
+        { tags: { has: dto.search } }
+      ];
+    }
+
+    if (dto.tag) {
+      where.tags = { has: dto.tag };
+    }
+
+    const items = await this.prisma.libraryItem.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' }
+    });
+
+    return items.map((item) => ({
+      id: item.id,
+      type: item.type,
+      title: item.title,
+      description: item.description,
+      tags: item.tags,
+      content: item.content
+    }));
+  }
+
+  async upsertLibraryItem(tenantId: string, dto: UpsertLibraryItemDto, actorId?: string | null) {
+    const data: Prisma.LibraryItemUncheckedCreateInput = {
+      tenantId,
+      type: dto.type,
+      title: dto.title,
+      description: dto.description ?? null,
+      content: dto.content as Prisma.JsonValue,
+      tags: dto.tags ?? []
+    };
+
+    let item;
+
+    if (dto.id) {
+      const existing = await this.prisma.libraryItem.findFirst({ where: { id: dto.id, tenantId } });
+      if (!existing) {
+        throw new NotFoundException('Library item not found');
+      }
+      item = await this.prisma.libraryItem.update({
+        where: { id: dto.id },
+        data
+      });
+    } else {
+      item = await this.prisma.libraryItem.create({ data });
+    }
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'library-item',
+      entityId: item.id,
+      type: 'audit.library.upserted',
+      diff: { type: dto.type }
+    });
+
+    return item;
+  }
+
   async createPlan(tenantId: string, dto: CreateAuditPlanDto, actorId?: string | null) {
+    const enrichedEngagements = await this.enrichEngagementMetrics(tenantId, dto.engagements);
+
     const plan = await this.prisma.auditPlan.create({
       data: {
         tenantId,
@@ -74,7 +174,7 @@ export class AuditService {
         status: dto.status ?? 'Draft',
         resourceModel: dto.resourceModel ?? null,
         engagements: {
-          create: dto.engagements.map((engagement) => ({
+          create: enrichedEngagements.map((engagement) => ({
             tenantId,
             title: engagement.title,
             scope: engagement.scope ?? null,
@@ -82,7 +182,9 @@ export class AuditService {
             start: engagement.start ?? null,
             end: engagement.end ?? null,
             entityRef: engagement.entityRef ?? null,
-            criticality: engagement.criticality ?? null
+            criticality: engagement.criticality ?? null,
+            priority: engagement.priority ?? null,
+            riskScore: engagement.riskScore ?? null
           }))
         }
       },
@@ -101,6 +203,8 @@ export class AuditService {
   }
 
   async createEngagement(tenantId: string, dto: CreateEngagementDto, actorId?: string | null) {
+    const [metrics] = await this.enrichEngagementMetrics(tenantId, [dto]);
+
     const engagement = await this.prisma.engagement.create({
       data: {
         tenantId,
@@ -113,6 +217,8 @@ export class AuditService {
         end: dto.end ?? null,
         entityRef: dto.entityRef ?? null,
         criticality: dto.criticality ?? null,
+        priority: metrics.priority ?? null,
+        riskScore: metrics.riskScore ?? null,
         team: dto.team ?? null
       }
     });
@@ -128,26 +234,106 @@ export class AuditService {
     return engagement;
   }
 
+  async generateDraftScope(
+    tenantId: string,
+    engagementId: string,
+    dto: GenerateDraftScopeDto,
+    actorId?: string | null
+  ) {
+    const engagement = await this.prisma.engagement.findFirst({
+      where: { id: engagementId, tenantId }
+    });
+
+    if (!engagement) {
+      throw new NotFoundException('Engagement not found');
+    }
+
+    const universe = engagement.entityRef
+      ? await this.prisma.auditUniverse.findFirst({ where: { id: engagement.entityRef, tenantId } })
+      : null;
+
+    const riskIds = dto.riskIds ?? universe?.linkedRiskIds ?? [];
+    const risks = riskIds.length
+      ? await this.prisma.risk.findMany({ where: { tenantId, id: { in: riskIds } } })
+      : [];
+
+    const libraryTypes = dto.libraryTypes ?? ['control', 'process', 'policy'];
+    const libraryItems = await this.prisma.libraryItem.findMany({
+      where: { tenantId, type: { in: libraryTypes } },
+      orderBy: { updatedAt: 'desc' }
+    });
+
+    const draft = this.planningProvider.generateDraftScope({
+      engagement: {
+        id: engagement.id,
+        title: engagement.title,
+        scope: engagement.scope ?? null
+      },
+      risks: risks.map((risk) => ({
+        id: risk.id,
+        title: risk.title,
+        residualScore: risk.residualScore ?? null,
+        status: risk.status
+      })),
+      libraryItems: libraryItems.map((item) => ({
+        id: item.id,
+        type: item.type,
+        title: item.title,
+        description: item.description,
+        content: (item.content as Record<string, unknown>) ?? {}
+      }))
+    });
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'engagement',
+      entityId: engagement.id,
+      type: 'audit.engagement.draft_scope.generated',
+      diff: { risks: riskIds.length, libraryItems: libraryItems.length }
+    });
+
+    return draft;
+  }
+
   async upsertRacm(tenantId: string, engagementId: string, dto: UpsertRacmDto, actorId?: string | null) {
     const engagement = await this.prisma.engagement.findFirst({ where: { id: engagementId, tenantId } });
     if (!engagement) {
       throw new NotFoundException('Engagement not found');
     }
 
-    await this.prisma.rACMLine.deleteMany({ where: { engagementId } });
-    await this.prisma.rACMLine.createMany({
-      data: dto.lines.map((line) => ({
+    const history = await this.prisma.rACMLine.findMany({ where: { engagementId } });
+    const versionMap = new Map<string, number>();
+    for (const line of history) {
+      const key = this.racmKey(line.process, line.riskRef, line.controlRef);
+      const current = versionMap.get(key) ?? 0;
+      versionMap.set(key, Math.max(current, line.version));
+    }
+
+    const createData = dto.lines.map((line) => {
+      const key = this.racmKey(line.process, line.riskRef, line.controlRef);
+      const nextVersion = (versionMap.get(key) ?? 0) + 1;
+      versionMap.set(key, nextVersion);
+      return {
         engagementId,
         process: line.process,
         riskRef: line.riskRef,
         controlRef: line.controlRef,
         assertion: line.assertion,
         testStep: line.testStep,
-        version: line.version ?? 1
-      }))
+        version: line.version ?? nextVersion,
+        isLatest: true
+      };
     });
 
-    const lines = await this.prisma.rACMLine.findMany({ where: { engagementId } });
+    await this.prisma.$transaction([
+      this.prisma.rACMLine.updateMany({ where: { engagementId }, data: { isLatest: false } }),
+      this.prisma.rACMLine.createMany({ data: createData })
+    ]);
+
+    const lines = await this.prisma.rACMLine.findMany({
+      where: { engagementId, isLatest: true },
+      orderBy: { createdAt: 'desc' }
+    });
 
     await this.events.record(tenantId, {
       actorId: actorId ?? null,
@@ -193,6 +379,37 @@ export class AuditService {
     });
 
     return workpaper;
+  }
+
+  async signWorkpaper(tenantId: string, workpaperId: string, dto: SignWorkpaperDto, actorId?: string | null) {
+    const workpaper = await this.prisma.workingPaper.findFirst({
+      where: { id: workpaperId, engagement: { tenantId } }
+    });
+
+    if (!workpaper) {
+      throw new NotFoundException('Workpaper not found');
+    }
+
+    const signedBy = dto.signature ?? actorId ?? workpaper.signedBy ?? null;
+    const signedAt = dto.signedAt ?? new Date();
+
+    const updated = await this.prisma.workingPaper.update({
+      where: { id: workpaperId },
+      data: {
+        signedBy,
+        signedAt
+      }
+    });
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'workpaper',
+      entityId: workpaperId,
+      type: 'audit.workpaper.signed',
+      diff: { signedBy }
+    });
+
+    return updated;
   }
 
   async createFinding(
@@ -248,11 +465,14 @@ export class AuditService {
 
     const existing = finding.followUps[0];
 
-    const data: Prisma.FollowUpUpdateInput = {
+    const baseData: Prisma.FollowUpUpdateInput = {
       status: dto.status ?? existing?.status ?? 'Open',
       evidenceRefs: dto.evidenceRefs ?? existing?.evidenceRefs ?? [],
       verifiedBy: dto.verify?.verifiedBy ?? existing?.verifiedBy ?? null,
-      verifiedAt: dto.verify?.verifiedAt ?? existing?.verifiedAt ?? null
+      verifiedAt: dto.verify?.verifiedAt ?? existing?.verifiedAt ?? null,
+      actionPlan: dto.actionPlan ?? existing?.actionPlan ?? null,
+      due: dto.due ?? existing?.due ?? null,
+      verificationNotes: dto.verify?.notes ?? existing?.verificationNotes ?? null
     };
 
     let followUp;
@@ -260,16 +480,19 @@ export class AuditService {
     if (existing) {
       followUp = await this.prisma.followUp.update({
         where: { id: existing.id },
-        data
+        data: baseData
       });
     } else {
       followUp = await this.prisma.followUp.create({
         data: {
           findingId,
-          status: data.status as string,
-          evidenceRefs: (data.evidenceRefs as string[]) ?? [],
-          verifiedBy: (data.verifiedBy as string | null) ?? null,
-          verifiedAt: (data.verifiedAt as Date | null) ?? null
+          status: baseData.status as string,
+          evidenceRefs: (baseData.evidenceRefs as string[]) ?? [],
+          verifiedBy: (baseData.verifiedBy as string | null) ?? null,
+          verifiedAt: (baseData.verifiedAt as Date | null) ?? null,
+          actionPlan: (baseData.actionPlan as string | null) ?? null,
+          due: (baseData.due as Date | null) ?? null,
+          verificationNotes: (baseData.verificationNotes as string | null) ?? null
         }
       });
     }
@@ -285,14 +508,389 @@ export class AuditService {
     return followUp;
   }
 
+  async createTimesheetEntry(tenantId: string, dto: CreateTimesheetEntryDto, actorId?: string | null) {
+    if (!actorId && !dto.id) {
+      throw new BadRequestException('User context is required for timesheet entry');
+    }
+
+    const engagement = await this.prisma.engagement.findFirst({ where: { id: dto.engagementId, tenantId } });
+    if (!engagement) {
+      throw new NotFoundException('Engagement not found');
+    }
+
+    const targetDate = dto.date;
+
+    let timesheet;
+
+    if (dto.id) {
+      const existing = await this.prisma.timesheet.findFirst({ where: { id: dto.id, tenantId } });
+      if (!existing) {
+        throw new NotFoundException('Timesheet entry not found');
+      }
+      timesheet = await this.prisma.timesheet.update({
+        where: { id: dto.id },
+        data: {
+          date: targetDate,
+          hours: dto.hours,
+          activity: dto.activity ?? null,
+          role: dto.role ?? existing.role ?? null,
+          approvalStatus: 'Pending',
+          approvedAt: null,
+          approvedBy: null
+        }
+      });
+    } else {
+      timesheet = await this.prisma.timesheet.upsert({
+        where: {
+          tenantId_userId_engagementId_date: {
+            tenantId,
+            userId: actorId as string,
+            engagementId: dto.engagementId,
+            date: targetDate
+          }
+        },
+        update: {
+          hours: dto.hours,
+          activity: dto.activity ?? null,
+          role: dto.role ?? null,
+          approvalStatus: 'Pending',
+          approvedAt: null,
+          approvedBy: null
+        },
+        create: {
+          tenantId,
+          userId: actorId as string,
+          engagementId: dto.engagementId,
+          date: targetDate,
+          hours: dto.hours,
+          activity: dto.activity ?? null,
+          role: dto.role ?? null
+        }
+      });
+    }
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'timesheet',
+      entityId: timesheet.id,
+      type: 'audit.timesheet.logged',
+      diff: { hours: timesheet.hours }
+    });
+
+    return timesheet;
+  }
+
+  async listTimesheets(tenantId: string, dto: ListTimesheetsDto) {
+    const where: Prisma.TimesheetWhereInput = { tenantId };
+
+    if (dto.engagementId) {
+      where.engagementId = dto.engagementId;
+    }
+
+    if (dto.userId) {
+      where.userId = dto.userId;
+    }
+
+    if (dto.start || dto.end) {
+      where.date = {};
+      if (dto.start) {
+        where.date.gte = dto.start;
+      }
+      if (dto.end) {
+        where.date.lte = dto.end;
+      }
+    }
+
+    const entries = await this.prisma.timesheet.findMany({
+      where,
+      orderBy: [{ date: 'desc' }, { createdAt: 'desc' }]
+    });
+
+    const totalHours = entries.reduce((sum, entry) => sum + entry.hours, 0);
+    const byEngagement = entries.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.engagementId] = (acc[entry.engagementId] ?? 0) + entry.hours;
+      return acc;
+    }, {});
+
+    return {
+      totalHours,
+      entries: entries.map((entry) => ({
+        id: entry.id,
+        engagementId: entry.engagementId,
+        userId: entry.userId,
+        date: entry.date.toISOString(),
+        hours: entry.hours,
+        activity: entry.activity,
+        role: entry.role,
+        approvalStatus: entry.approvalStatus,
+        approvedBy: entry.approvedBy,
+        approvedAt: entry.approvedAt ? entry.approvedAt.toISOString() : null
+      })),
+      byEngagement
+    };
+  }
+
+  async approveTimesheet(
+    tenantId: string,
+    timesheetId: string,
+    dto: ApproveTimesheetDto,
+    actorId?: string | null
+  ) {
+    if (!actorId) {
+      throw new BadRequestException('Actor is required to approve timesheets');
+    }
+
+    const timesheet = await this.prisma.timesheet.findFirst({ where: { id: timesheetId, tenantId } });
+    if (!timesheet) {
+      throw new NotFoundException('Timesheet entry not found');
+    }
+
+    const approved = await this.prisma.timesheet.update({
+      where: { id: timesheetId },
+      data: {
+        approvalStatus: 'Approved',
+        approvedBy: actorId,
+        approvedAt: dto.approvedAt ?? new Date()
+      }
+    });
+
+    await this.events.record(tenantId, {
+      actorId,
+      entity: 'timesheet',
+      entityId: timesheetId,
+      type: 'audit.timesheet.approved',
+      diff: { approvedBy: actorId }
+    });
+
+    return approved;
+  }
+
+  async planUtilization(tenantId: string, planId: string) {
+    const plan = await this.prisma.auditPlan.findFirst({
+      where: { id: planId, tenantId },
+      include: { engagements: true }
+    });
+
+    if (!plan) {
+      throw new NotFoundException('Audit plan not found');
+    }
+
+    const resourceModel = this.parseResourceModel(plan.resourceModel);
+    const engagementIds = plan.engagements.map((engagement) => engagement.id);
+
+    const timesheets = await this.prisma.timesheet.findMany({
+      where: { tenantId, engagementId: { in: engagementIds } }
+    });
+
+    const roleSet = new Set<string>([
+      ...Object.keys(resourceModel.capacity ?? {}),
+      ...(resourceModel.allocations ?? []).map((allocation) => allocation.role ?? 'Unspecified'),
+      ...timesheets.map((entry) => entry.role ?? 'Unspecified')
+    ]);
+
+    const roleSummaries = Array.from(roleSet).map((role) => {
+      const planned = (resourceModel.allocations ?? [])
+        .filter((allocation) => (allocation.role ?? 'Unspecified') === role)
+        .reduce((sum, allocation) => sum + allocation.hours, 0);
+      const capacity = (resourceModel.capacity ?? {})[role] ?? planned;
+      const actual = timesheets
+        .filter((entry) => (entry.role ?? 'Unspecified') === role)
+        .reduce((sum, entry) => sum + entry.hours, 0);
+      const utilization = capacity > 0 ? actual / capacity : actual > 0 ? 1 : 0;
+      return {
+        role,
+        capacityHours: capacity,
+        plannedHours: planned,
+        actualHours: actual,
+        variance: actual - planned,
+        utilization
+      };
+    });
+
+    const engagementSummaries = plan.engagements.map((engagement) => {
+      const planned = (resourceModel.allocations ?? [])
+        .filter((allocation) => allocation.engagementId === engagement.id)
+        .reduce((sum, allocation) => sum + allocation.hours, 0);
+      const actual = timesheets
+        .filter((entry) => entry.engagementId === engagement.id)
+        .reduce((sum, entry) => sum + entry.hours, 0);
+      return {
+        engagementId: engagement.id,
+        title: engagement.title,
+        plannedHours: planned,
+        actualHours: actual,
+        variance: actual - planned,
+        priority: engagement.priority ?? null,
+        status: engagement.status
+      };
+    });
+
+    return {
+      planId: plan.id,
+      period: plan.period,
+      roles: roleSummaries,
+      engagements: engagementSummaries
+    };
+  }
+
+  async upsertAuditProgram(
+    tenantId: string,
+    engagementId: string,
+    dto: UpsertAuditProgramDto,
+    actorId?: string | null
+  ) {
+    const engagement = await this.prisma.engagement.findFirst({ where: { id: engagementId, tenantId } });
+    if (!engagement) {
+      throw new NotFoundException('Engagement not found');
+    }
+
+    const latest = await this.prisma.auditProgram.findFirst({
+      where: { engagementId },
+      orderBy: { version: 'desc' }
+    });
+
+    const program = await this.prisma.$transaction(async (tx) => {
+      if (latest) {
+        await tx.auditProgram.update({
+          where: { id: latest.id },
+          data: { status: 'Superseded' }
+        });
+      }
+
+      const created = await tx.auditProgram.create({
+        data: {
+          tenantId,
+          engagementId,
+          name: dto.name ?? latest?.name ?? 'Engagement Program',
+          status: dto.status ?? 'Draft',
+          metadata: dto.metadata ?? null,
+          version: (latest?.version ?? 0) + 1,
+          publishedAt: dto.status && dto.status !== 'Draft' ? new Date() : null,
+          steps: {
+            create: dto.steps.map((step, index) => ({
+              order: step.order ?? index + 1,
+              title: step.title,
+              description: step.description ?? null,
+              testProcedure: step.testProcedure,
+              evidence: step.evidence ?? null,
+              controlRef: step.controlRef ?? null,
+              assertion: step.assertion ?? null,
+              riskRef: step.riskRef ?? null
+            }))
+          }
+        },
+        include: { steps: { orderBy: { order: 'asc' } } }
+      });
+
+      return created;
+    });
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'audit-program',
+      entityId: program.id,
+      type: 'audit.program.upserted',
+      diff: { version: program.version, steps: program.steps.length }
+    });
+
+    return program;
+  }
+
+  async getLatestProgram(tenantId: string, engagementId: string) {
+    const program = await this.prisma.auditProgram.findFirst({
+      where: { engagementId, tenantId },
+      orderBy: { version: 'desc' },
+      include: { steps: { orderBy: { order: 'asc' } } }
+    });
+
+    if (!program) {
+      throw new NotFoundException('Program not found');
+    }
+
+    return program;
+  }
+
+  async upsertReportTemplate(tenantId: string, dto: UpsertReportTemplateDto, actorId?: string | null) {
+    const data: Prisma.ReportTemplateUncheckedCreateInput = {
+      tenantId,
+      name: dto.name,
+      sections: dto.sections as unknown as Prisma.JsonValue,
+      placeholders: dto.placeholders
+    };
+
+    let template;
+    if (dto.id) {
+      const existing = await this.prisma.reportTemplate.findFirst({ where: { id: dto.id, tenantId } });
+      if (!existing) {
+        throw new NotFoundException('Report template not found');
+      }
+      template = await this.prisma.reportTemplate.update({ where: { id: dto.id }, data });
+    } else {
+      template = await this.prisma.reportTemplate.create({ data });
+    }
+
+    await this.events.record(tenantId, {
+      actorId: actorId ?? null,
+      entity: 'report-template',
+      entityId: template.id,
+      type: 'audit.report_template.upserted',
+      diff: { name: template.name }
+    });
+
+    return template;
+  }
+
+  async listReportTemplates(tenantId: string) {
+    return this.prisma.reportTemplate.findMany({
+      where: { tenantId },
+      orderBy: { createdAt: 'desc' }
+    });
+  }
+
   async generateReport(dto: GenerateReportDto, actorId?: string | null) {
+    const template = await this.ensureReportTemplate(dto.tenantId, dto.templateKey);
+
+    const engagement = dto.engagementId
+      ? await this.prisma.engagement.findFirst({
+          where: { id: dto.engagementId, tenantId: dto.tenantId },
+          include: {
+            findings: true,
+            racmLines: { where: { isLatest: true } }
+          }
+        })
+      : null;
+
+    if (dto.engagementId && !engagement) {
+      throw new NotFoundException('Engagement not found for report generation');
+    }
+
+    const risks = await this.prisma.risk.findMany({ where: { tenantId: dto.tenantId } });
+    const plan = dto.auditPlanId
+      ? await this.prisma.auditPlan.findFirst({ where: { id: dto.auditPlanId, tenantId: dto.tenantId } })
+      : null;
+
+    const options = dto.options ?? { includeFindings: true };
+    const placeholders = this.buildReportPlaceholders({ engagement, plan, risks, options });
+    const renderedSections = template.sections.map((section) => ({
+      title: section.title,
+      body: this.resolvePlaceholders(section.body, placeholders)
+    }));
+
+    const pdfBuffer = await this.renderPdf({
+      title: template.name,
+      sections: renderedSections
+    });
+
+    const checksum = createHash('sha256').update(pdfBuffer).digest('hex');
+    const storageKey = dto.outputName ? `reports/${dto.outputName.replace(/\s+/g, '-').toLowerCase()}.pdf` : `reports/${randomUUID()}.pdf`;
+
     const report = await this.prisma.report.create({
       data: {
         tenantId: dto.tenantId,
-        templateId: dto.templateId ?? null,
+        templateId: template.id,
         engagementId: dto.engagementId ?? null,
         auditPlanId: dto.auditPlanId ?? null,
-        fileRef: dto.fileRef
+        fileRef: storageKey
       }
     });
 
@@ -301,10 +899,15 @@ export class AuditService {
       entity: 'report',
       entityId: report.id,
       type: 'report.generated',
-      diff: { fileRef: dto.fileRef }
+      diff: { template: template.name, checksum }
     });
 
-    return report;
+    return {
+      report,
+      storageKey,
+      checksum,
+      pdf: pdfBuffer.toString('base64')
+    };
   }
 
   async listEngagements(tenantId: string) {
@@ -325,6 +928,8 @@ export class AuditService {
       status: engagement.status,
       startDate: engagement.start ? engagement.start.toISOString() : null,
       findingsOpen: engagement.findings.length,
+      priority: engagement.priority ?? null,
+      riskScore: engagement.riskScore ?? null,
       owner:
         engagement.team && typeof engagement.team === 'object' && !Array.isArray(engagement.team)
           ? ((engagement.team as Record<string, unknown>).lead as string | undefined) ?? null
@@ -333,7 +938,7 @@ export class AuditService {
   }
 
   async dashboard(tenantId: string) {
-    const [plans, engagements, findings, timesheets, followUps, userCount] = await this.prisma.$transaction([
+    const [plans, engagements, findings, timesheets, followUps, userCount, risks] = await this.prisma.$transaction([
       this.prisma.auditPlan.findMany({
         where: { tenantId },
         include: { engagements: true }
@@ -346,8 +951,9 @@ export class AuditService {
         where: { engagement: { tenantId }, status: { not: 'Closed' } }
       }),
       this.prisma.timesheet.findMany({ where: { tenantId } }),
-      this.prisma.followUp.findMany({ where: { finding: { engagement: { tenant: { id: tenantId } } } } }),
-      this.prisma.user.count({ where: { tenantId } })
+      this.prisma.followUp.findMany({ where: { finding: { engagement: { tenantId } } } }),
+      this.prisma.user.count({ where: { tenantId } }),
+      this.prisma.risk.findMany({ where: { tenantId } })
     ]);
 
     const planProgress = plans.map((plan) => {
@@ -380,7 +986,11 @@ export class AuditService {
     );
 
     const bookedHours = timesheets.reduce((sum, entry) => sum + entry.hours, 0);
-    const totalCapacity = Math.max(userCount * 160, bookedHours);
+    const plannedHours = plans.reduce((total, plan) => {
+      const model = this.parseResourceModel(plan.resourceModel);
+      return total + (model.allocations ?? []).reduce((sum, allocation) => sum + allocation.hours, 0);
+    }, 0);
+    const totalCapacity = Math.max(userCount * 160, bookedHours, plannedHours);
     const utilizationRate = totalCapacity > 0 ? bookedHours / totalCapacity : 0;
 
     const indicatorSummary = followUps.reduce<Record<string, number>>((acc, followUp) => {
@@ -389,6 +999,33 @@ export class AuditService {
       return acc;
     }, {});
 
+    const followUpAging = followUps.reduce(
+      (acc, followUp) => {
+        if (followUp.due && followUp.status !== 'Closed') {
+          const overdue = differenceInDays(now, followUp.due);
+          if (overdue > 0) {
+            acc.overdue += 1;
+          }
+        }
+        acc.total += 1;
+        return acc;
+      },
+      { overdue: 0, total: 0 }
+    );
+
+    const riskHeatmap = this.buildHeatmap(risks);
+    const topRisks = [...risks]
+      .sort((a, b) => (b.residualScore ?? 0) - (a.residualScore ?? 0))
+      .slice(0, 5)
+      .map((risk) => ({
+        id: risk.id,
+        title: risk.title,
+        residualScore: risk.residualScore ?? null,
+        appetiteBreached: risk.appetiteBreached
+      }));
+
+    const appetiteBreaches = risks.filter((risk) => risk.appetiteBreached).length;
+
     return {
       planProgress,
       findingsBySeverity,
@@ -396,16 +1033,231 @@ export class AuditService {
       utilization: {
         totalCapacity,
         bookedHours,
+        plannedHours,
         utilizationRate
       },
+      indicatorSummary,
+      followUpAging,
+      riskHeatmap,
+      topRisks,
+      appetiteBreaches,
       engagements: engagements.map((engagement) => ({
         id: engagement.id,
         title: engagement.title,
         status: engagement.status,
         startDate: engagement.start ? engagement.start.toISOString() : null,
-        findingsOpen: engagement.findings.filter((finding) => finding.status !== 'Closed').length
-      })),
-      indicatorSummary
+        findingsOpen: engagement.findings.filter((finding) => finding.status !== 'Closed').length,
+        priority: engagement.priority ?? null
+      }))
     };
+  }
+
+  private racmKey(process: string, riskRef: string, controlRef: string) {
+    return `${process}::${riskRef}::${controlRef}`;
+  }
+
+  private async enrichEngagementMetrics(
+    tenantId: string,
+    engagements: Array<CreateEngagementDto & EngagementPlanInput>
+  ) {
+    const entityIds = engagements
+      .map((engagement) => engagement.entityRef)
+      .filter((entityId): entityId is string => Boolean(entityId));
+
+    const [entities, risks] = await Promise.all([
+      entityIds.length
+        ? this.prisma.auditUniverse.findMany({ where: { tenantId, id: { in: entityIds } } })
+        : Promise.resolve([]),
+      this.prisma.risk.findMany({ where: { tenantId } })
+    ]);
+
+    const entityMap = new Map(entities.map((entity) => [entity.id, entity]));
+    const riskMap = new Map(risks.map((risk) => [risk.id, risk]));
+
+    return engagements.map((engagement) => {
+      const entity = engagement.entityRef ? entityMap.get(engagement.entityRef) : undefined;
+      const linkedRisks = entity?.linkedRiskIds ?? [];
+      const riskValues = linkedRisks
+        .map((riskId) => riskMap.get(riskId))
+        .filter((risk): risk is typeof risks[number] => Boolean(risk))
+        .map((risk) => risk.residualScore ?? risk.inherentL * risk.inherentI);
+
+      const avgRisk =
+        riskValues.length > 0
+          ? riskValues.reduce((sum, score) => sum + score, 0) / riskValues.length
+          : engagement.riskScore ?? (entity?.criticality ?? engagement.criticality ?? 1) * 5;
+
+      const lastAudit = entity?.lastAudit ?? null;
+      const recencyBoost = lastAudit ? Math.min(Math.max(differenceInDays(new Date(), lastAudit), 0) / 30, 12) : 6;
+      const priority = engagement.priority ?? Math.max(1, Math.round(avgRisk + recencyBoost));
+
+      return {
+        ...engagement,
+        priority,
+        riskScore: avgRisk
+      };
+    });
+  }
+
+  private parseResourceModel(model: unknown): ResourceModel {
+    if (!model || typeof model !== 'object') {
+      return { capacity: {}, allocations: [] };
+    }
+
+    const resourceModel = model as ResourceModel;
+    return {
+      capacity: resourceModel.capacity ?? {},
+      allocations: resourceModel.allocations ?? []
+    };
+  }
+
+  private async ensureReportTemplate(tenantId: string, key: string) {
+    let template = await this.prisma.reportTemplate.findFirst({ where: { tenantId, name: key } });
+
+    if (!template) {
+      const defaults: Record<string, ReportSection[]> = {
+        'engagement-report': [
+          {
+            title: 'Engagement Overview',
+            body: 'Engagement: ${engagement.title}\nScope: ${engagement.scope}\nObjectives: ${engagement.objectives}'
+          },
+          {
+            title: 'Findings Summary',
+            body: '${findings.table}'
+          },
+          {
+            title: 'Risk Heat Map',
+            body: '${summary.heatmap}'
+          }
+        ],
+        'issues-log': [
+          {
+            title: 'Open Issues',
+            body: '${findings.table}'
+          },
+          {
+            title: 'Follow-up Status',
+            body: 'Open follow-ups: ${followUps.total}\nOverdue: ${followUps.overdue}'
+          }
+        ]
+      };
+
+      const sections = defaults[key] ?? [
+        {
+          title: 'Summary',
+          body: 'Engagement ${engagement.title} generated report.'
+        }
+      ];
+
+      template = await this.prisma.reportTemplate.create({
+        data: {
+          tenantId,
+          name: key,
+          sections: sections as unknown as Prisma.JsonValue,
+          placeholders: ['engagement.title', 'findings.table', 'summary.heatmap', 'followUps.total', 'followUps.overdue']
+        }
+      });
+    }
+
+    return template;
+  }
+
+  private buildReportPlaceholders({
+    engagement,
+    plan,
+    risks,
+    options
+  }: {
+    engagement: (Prisma.EngagementGetPayload<{ include: { findings: true; racmLines: true } }> | null) | null;
+    plan: Prisma.AuditPlan | null;
+    risks: Prisma.Risk[];
+    options: GenerateReportDto['options'];
+  }) {
+    const findingsTable = engagement && options.includeFindings !== false
+      ? this.buildFindingsTable(engagement.findings)
+      : 'No findings included in this report.';
+
+    const heatmap = this.buildHeatmap(risks);
+
+    return {
+      'engagement.title': engagement?.title ?? 'N/A',
+      'engagement.scope': engagement?.scope ?? 'N/A',
+      'engagement.objectives': engagement?.objectives ?? 'N/A',
+      'plan.period': plan?.period ?? 'N/A',
+      'findings.table': findingsTable,
+      'summary.heatmap': heatmap,
+      'summary.override': options.summaryOverride ?? null,
+      'followUps.total': engagement?.findings.length ?? 0,
+      'followUps.overdue': engagement
+        ? engagement.findings.filter((finding) => finding.due && finding.due < new Date() && finding.status !== 'Closed').length
+        : 0
+    };
+  }
+
+  private resolvePlaceholders(template: string, placeholders: Record<string, unknown>) {
+    return template.replace(/\$\{([^}]+)\}/g, (_, key: string) => {
+      const value = placeholders[key];
+      if (value === null || value === undefined) {
+        return 'N/A';
+      }
+      if (typeof value === 'object') {
+        return JSON.stringify(value, null, 2);
+      }
+      return String(value);
+    });
+  }
+
+  private async renderPdf({ title, sections }: { title: string; sections: ReportSection[] }) {
+    return new Promise<Buffer>((resolve, reject) => {
+      const doc = new PDFDocument({ margin: 50 });
+      const chunks: Buffer[] = [];
+      doc.on('data', (chunk) => chunks.push(chunk));
+      doc.on('error', (error) => reject(error));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+
+      doc.fontSize(18).text(title, { underline: true });
+      doc.moveDown();
+
+      sections.forEach((section) => {
+        doc.fontSize(14).text(section.title, { underline: true });
+        doc.moveDown(0.5);
+        doc.fontSize(11).text(section.body);
+        doc.moveDown();
+      });
+
+      doc.end();
+    });
+  }
+
+  private buildFindingsTable(findings: Prisma.Finding[]) {
+    if (findings.length === 0) {
+      return 'No open findings.';
+    }
+
+    const header = 'Severity | Condition | Owner | Due | Status';
+    const separator = '---|---|---|---|---';
+    const rows = findings.map((finding) => {
+      const due = finding.due ? finding.due.toISOString().split('T')[0] : 'N/A';
+      return `${finding.severity} | ${finding.condition} | ${finding.ownerId ?? 'N/A'} | ${due} | ${finding.status}`;
+    });
+
+    return [header, separator, ...rows].join('\n');
+  }
+
+  private buildHeatmap(risks: Prisma.Risk[]) {
+    const grid = Array.from({ length: 5 }, () => Array(5).fill(0));
+
+    risks.forEach((risk) => {
+      const likelihood = Math.min(Math.max(risk.residualL ?? risk.inherentL ?? 1, 1), 5);
+      const impact = Math.min(Math.max(risk.residualI ?? risk.inherentI ?? 1, 1), 5);
+      grid[5 - impact][likelihood - 1] += 1;
+    });
+
+    const header = ['Impact\\Likelihood', '1', '2', '3', '4', '5'];
+    const rows = grid.map((row, index) => {
+      return `${5 - index} | ${row.join(' | ')}`;
+    });
+
+    return [header.join(' | '), '---|---|---|---|---|---', ...rows].join('\n');
   }
 }

--- a/apps/api/src/audit/dto/approve-timesheet.dto.ts
+++ b/apps/api/src/audit/dto/approve-timesheet.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const approveTimesheetSchema = z.object({
+  approvedAt: z.coerce.date().optional()
+});
+
+export type ApproveTimesheetDto = z.infer<typeof approveTimesheetSchema>;

--- a/apps/api/src/audit/dto/create-audit-plan.dto.ts
+++ b/apps/api/src/audit/dto/create-audit-plan.dto.ts
@@ -13,7 +13,9 @@ export const createAuditPlanSchema = z.object({
         start: z.coerce.date().optional(),
         end: z.coerce.date().optional(),
         entityRef: z.string().optional(),
-        criticality: z.number().int().min(1).max(5).optional()
+        criticality: z.number().int().min(1).max(5).optional(),
+        priority: z.number().int().min(1).optional(),
+        riskScore: z.number().min(0).optional()
       })
     )
     .default([])

--- a/apps/api/src/audit/dto/create-engagement.dto.ts
+++ b/apps/api/src/audit/dto/create-engagement.dto.ts
@@ -10,6 +10,8 @@ export const createEngagementSchema = z.object({
   end: z.coerce.date().optional(),
   entityRef: z.string().optional(),
   criticality: z.number().int().min(1).max(5).optional(),
+  priority: z.number().int().min(1).optional(),
+  riskScore: z.number().min(0).optional(),
   team: z.record(z.any()).optional()
 });
 

--- a/apps/api/src/audit/dto/create-follow-up.dto.ts
+++ b/apps/api/src/audit/dto/create-follow-up.dto.ts
@@ -3,10 +3,13 @@ import { z } from 'zod';
 export const createFollowUpSchema = z.object({
   evidenceRefs: z.array(z.string()).default([]),
   status: z.string().default('Open'),
+  actionPlan: z.string().optional(),
+  due: z.coerce.date().optional(),
   verify: z
     .object({
       verifiedBy: z.string().uuid(),
-      verifiedAt: z.coerce.date()
+      verifiedAt: z.coerce.date(),
+      notes: z.string().optional()
     })
     .optional()
 });

--- a/apps/api/src/audit/dto/create-timesheet-entry.dto.ts
+++ b/apps/api/src/audit/dto/create-timesheet-entry.dto.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const createTimesheetEntrySchema = z.object({
+  id: z.string().cuid().optional(),
+  engagementId: z.string().cuid(),
+  date: z.coerce.date(),
+  hours: z.number().min(0).max(24),
+  activity: z.string().optional(),
+  role: z.string().optional()
+});
+
+export type CreateTimesheetEntryDto = z.infer<typeof createTimesheetEntrySchema>;
+
+export const listTimesheetsSchema = z.object({
+  start: z.coerce.date().optional(),
+  end: z.coerce.date().optional(),
+  engagementId: z.string().cuid().optional(),
+  userId: z.string().cuid().optional()
+});
+
+export type ListTimesheetsDto = z.infer<typeof listTimesheetsSchema>;

--- a/apps/api/src/audit/dto/generate-draft-scope.dto.ts
+++ b/apps/api/src/audit/dto/generate-draft-scope.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { libraryItemTypes } from './upsert-library-item.dto';
+
+export const generateDraftScopeSchema = z.object({
+  libraryTypes: z.array(z.enum(libraryItemTypes)).optional(),
+  riskIds: z.array(z.string().cuid()).optional(),
+  includeControls: z.boolean().default(true)
+});
+
+export type GenerateDraftScopeDto = z.infer<typeof generateDraftScopeSchema>;

--- a/apps/api/src/audit/dto/generate-report.dto.ts
+++ b/apps/api/src/audit/dto/generate-report.dto.ts
@@ -1,11 +1,19 @@
 import { z } from 'zod';
 
+export const reportTemplateKeys = ['engagement-report', 'issues-log'] as const;
+
 export const generateReportSchema = z.object({
   tenantId: z.string().cuid(),
-  templateId: z.string().cuid().optional(),
+  templateKey: z.enum(reportTemplateKeys),
   engagementId: z.string().cuid().optional(),
   auditPlanId: z.string().cuid().optional(),
-  fileRef: z.string().min(3)
+  options: z
+    .object({
+      includeFindings: z.boolean().default(true),
+      summaryOverride: z.string().optional()
+    })
+    .default({ includeFindings: true }),
+  outputName: z.string().min(3).optional()
 });
 
 export type GenerateReportDto = z.infer<typeof generateReportSchema>;

--- a/apps/api/src/audit/dto/sign-workpaper.dto.ts
+++ b/apps/api/src/audit/dto/sign-workpaper.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const signWorkpaperSchema = z.object({
+  signature: z.string().min(2).optional(),
+  signedAt: z.coerce.date().optional()
+});
+
+export type SignWorkpaperDto = z.infer<typeof signWorkpaperSchema>;

--- a/apps/api/src/audit/dto/upsert-audit-program.dto.ts
+++ b/apps/api/src/audit/dto/upsert-audit-program.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const upsertAuditProgramSchema = z.object({
+  programId: z.string().cuid().optional(),
+  name: z.string().min(3).default('Engagement Program'),
+  status: z.string().default('Draft'),
+  metadata: z.record(z.any()).optional(),
+  steps: z
+    .array(
+      z.object({
+        order: z.number().int().min(1).optional(),
+        title: z.string().min(3),
+        description: z.string().optional(),
+        testProcedure: z.string().min(3),
+        evidence: z.string().optional(),
+        controlRef: z.string().optional(),
+        assertion: z.string().optional(),
+        riskRef: z.string().optional()
+      })
+    )
+    .min(1)
+});
+
+export type UpsertAuditProgramDto = z.infer<typeof upsertAuditProgramSchema>;

--- a/apps/api/src/audit/dto/upsert-library-item.dto.ts
+++ b/apps/api/src/audit/dto/upsert-library-item.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const libraryItemTypes = ['control', 'process', 'policy'] as const;
+
+export const upsertLibraryItemSchema = z.object({
+  id: z.string().cuid().optional(),
+  type: z.enum(libraryItemTypes),
+  title: z.string().min(3),
+  description: z.string().optional(),
+  content: z
+    .union([z.string(), z.record(z.any())])
+    .transform((value) => (typeof value === 'string' ? { body: value } : value)),
+  tags: z.array(z.string()).default([])
+});
+
+export type UpsertLibraryItemDto = z.infer<typeof upsertLibraryItemSchema>;
+
+export const listLibraryItemsSchema = z.object({
+  type: z.enum(libraryItemTypes).optional(),
+  search: z.string().optional(),
+  tag: z.string().optional()
+});
+
+export type ListLibraryItemsDto = z.infer<typeof listLibraryItemsSchema>;

--- a/apps/api/src/audit/dto/upsert-report-template.dto.ts
+++ b/apps/api/src/audit/dto/upsert-report-template.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const upsertReportTemplateSchema = z.object({
+  id: z.string().cuid().optional(),
+  name: z.string().min(3),
+  sections: z.array(z.object({ title: z.string(), body: z.string() })).min(1),
+  placeholders: z.array(z.string()).default([])
+});
+
+export type UpsertReportTemplateDto = z.infer<typeof upsertReportTemplateSchema>;

--- a/apps/api/src/audit/planning/planning.provider.ts
+++ b/apps/api/src/audit/planning/planning.provider.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@nestjs/common';
+
+export type DraftScopeInput = {
+  engagement: {
+    id: string;
+    title: string;
+    scope: string | null;
+  };
+  risks: Array<{
+    id: string;
+    title: string;
+    residualScore: number | null;
+    status: string;
+  }>;
+  libraryItems: Array<{
+    id: string;
+    type: string;
+    title: string;
+    description?: string | null;
+    content: Record<string, unknown>;
+  }>;
+};
+
+export type DraftScopeOutput = {
+  scopeStatement: string;
+  suggestedObjectives: string[];
+  testPlan: Array<{
+    title: string;
+    description: string;
+    evidence: string[];
+  }>;
+  referencedLibraryItems: string[];
+};
+
+export interface AuditPlanningProvider {
+  generateDraftScope(input: DraftScopeInput): DraftScopeOutput;
+}
+
+@Injectable()
+export class DeterministicPlanningProvider implements AuditPlanningProvider {
+  generateDraftScope(input: DraftScopeInput): DraftScopeOutput {
+    const sortedRisks = [...input.risks].sort((a, b) => (b.residualScore ?? 0) - (a.residualScore ?? 0));
+    const topRiskTitles = sortedRisks.map((risk) => risk.title);
+
+    const scopeStatement = [
+      `Assess the design and operating effectiveness of ${input.engagement.title}.`,
+      topRiskTitles.length > 0
+        ? `Focus on the following risks: ${topRiskTitles.join(', ')}.`
+        : 'No specific linked risks were provided; cover standard control objectives.',
+      (() => {
+        const controlTitles = input.libraryItems
+          .filter((item) => item.type === 'control')
+          .map((item) => item.title);
+        return controlTitles.length > 0
+          ? `Reference catalog controls: ${controlTitles.join(', ')}.`
+          : 'Leverage catalog narratives and policies to inform procedures.';
+      })()
+    ].join(' ');
+
+    const suggestedObjectives = [
+      `Validate control coverage for ${input.engagement.title}.`,
+      topRiskTitles.length > 0
+        ? `Confirm mitigation plans remain effective for ${topRiskTitles[0]}.`
+        : 'Confirm baseline control operations across the process.'
+    ];
+
+    const testPlan = sortedRisks.map((risk, index) => {
+      const relatedControls = input.libraryItems.filter((item) => {
+        if (item.type !== 'control') {
+          return false;
+        }
+        const riskId = item.content['riskId'];
+        const risksList = item.content['risks'];
+        if (typeof riskId === 'string' && riskId === risk.id) {
+          return true;
+        }
+        if (Array.isArray(risksList)) {
+          return (risksList as unknown[]).some((value) => value === risk.id);
+        }
+        return false;
+      });
+
+      const evidence = [
+        'Sampling evidence of key controls',
+        'Walkthrough documentation'
+      ];
+
+      if (relatedControls.length > 0) {
+        evidence.push(`Control design reference: ${relatedControls.map((control) => control.title).join(', ')}`);
+      }
+
+      return {
+        title: `Test step ${index + 1}: ${risk.title}`,
+        description: `Perform procedures to evaluate the residual risk status (${risk.status}) and confirm controls remain effective.`,
+        evidence
+      };
+    });
+
+    if (testPlan.length === 0) {
+      testPlan.push({
+        title: 'Baseline control walkthrough',
+        description: 'Perform walkthroughs over key process areas leveraging catalog narratives.',
+        evidence: ['Narrative acknowledgement', 'Sample population list']
+      });
+    }
+
+    const referencedLibraryItems = input.libraryItems.map((item) => item.id);
+
+    return {
+      scopeStatement,
+      suggestedObjectives,
+      testPlan,
+      referencedLibraryItems
+    };
+  }
+}

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -34,6 +34,8 @@ model Tenant {
   auditPlans AuditPlan[]
   engagements Engagement[]
   timesheets Timesheet[]
+  libraryItems LibraryItem[]
+  auditPrograms AuditProgram[]
   reports    Report[]
   reportTemplates ReportTemplate[]
   events     Event[]
@@ -58,6 +60,7 @@ model User {
   assignedTreatments Treatment[] @relation("TreatmentOwner")
   ownedControls Control[] @relation("ControlOwner")
   refreshTokens RefreshToken[]
+  approvedTimesheets Timesheet[] @relation("TimesheetApprover")
 }
 
 model Risk {
@@ -237,6 +240,8 @@ model Engagement {
   end          DateTime?
   entityRef    String?
   criticality  Int?
+  priority     Int?
+  riskScore    Float?
   team         Json?
   tenant       Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   auditPlan    AuditPlan? @relation(fields: [auditPlanId], references: [id], onDelete: SetNull)
@@ -245,6 +250,7 @@ model Engagement {
   findings     Finding[]
   timesheets   Timesheet[]
   reports      Report[]
+  programs     AuditProgram[]
 }
 
 model RACMLine {
@@ -256,6 +262,8 @@ model RACMLine {
   assertion    String
   testStep     String
   version      Int      @default(1)
+  isLatest     Boolean  @default(true)
+  createdAt    DateTime @default(now())
   engagement   Engagement @relation(fields: [engagementId], references: [id], onDelete: Cascade)
 }
 
@@ -298,6 +306,9 @@ model FollowUp {
   evidenceRefs String[]
   verifiedBy String?
   verifiedAt DateTime?
+  actionPlan String?
+  due        DateTime?
+  verificationNotes String?
   updatedAt  DateTime @updatedAt
   finding    Finding  @relation(fields: [findingId], references: [id], onDelete: Cascade)
   verifier   User?    @relation("FollowUpVerifier", fields: [verifiedBy], references: [id])
@@ -311,11 +322,61 @@ model Timesheet {
   date         DateTime
   hours        Float
   activity     String?
+  role         String?
   approvalStatus String @default("Pending")
+  approvedBy   String?
+  approvedAt   DateTime?
   createdAt    DateTime @default(now())
   tenant       Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   engagement   Engagement @relation(fields: [engagementId], references: [id], onDelete: Cascade)
   user         User     @relation(fields: [userId], references: [id])
+  approver     User?    @relation("TimesheetApprover", fields: [approvedBy], references: [id])
+
+  @@unique([tenantId, userId, engagementId, date])
+}
+
+model LibraryItem {
+  id          String   @id @default(cuid())
+  tenantId    String
+  type        String
+  title       String
+  description String?
+  content     Json
+  tags        String[] @default([])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  tenant      Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+}
+
+model AuditProgram {
+  id           String   @id @default(cuid())
+  tenantId     String
+  engagementId String
+  name         String
+  version      Int      @default(1)
+  status       String   @default("Draft")
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  publishedAt  DateTime?
+  tenant       Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  engagement   Engagement @relation(fields: [engagementId], references: [id], onDelete: Cascade)
+  steps        AuditProgramStep[]
+}
+
+model AuditProgramStep {
+  id            String   @id @default(cuid())
+  programId     String
+  order         Int
+  title         String
+  description   String?
+  testProcedure String
+  evidence      String?
+  controlRef    String?
+  assertion     String?
+  riskRef       String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  program       AuditProgram @relation(fields: [programId], references: [id], onDelete: Cascade)
 }
 
 model ReportTemplate {


### PR DESCRIPTION
## Summary
- add catalog endpoints and deterministic draft scope generation to support AI-assisted audit planning
- implement timesheet entry, approval, and plan utilization APIs with supporting Prisma schema updates
- extend audit programs, report templating, and PDF generation alongside enhanced dashboard metrics

## Testing
- pnpm --filter @open-erm/api lint *(fails: ESLint flat config/root mismatch and missing dependencies because registry access requires credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d3bd91c08328bdee76fec484dd0b